### PR TITLE
Replace crc with crc32fast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ A crate for decoding and encoding the header part of gzip files based on the gzi
 categories = ["compression"]
 
 [dependencies]
-crc = "1.5.0"
+crc32fast = "1.2.0"

--- a/src/crc_reader.rs
+++ b/src/crc_reader.rs
@@ -4,7 +4,7 @@ use std::io::{BufRead, Read};
 use std::io;
 use std::fmt;
 
-use crc::crc32;
+use crc32fast::Hasher;
 
 /// A wrapper struct containing a CRC checksum in the format used by gzip and the amount of bytes
 /// input to it mod 2^32.
@@ -59,7 +59,9 @@ impl Crc {
     /// Update the checksum and byte counter with the provided data.
     pub fn update(&mut self, data: &[u8]) {
         self.amt = self.amt.wrapping_add(data.len() as u32);
-        self.checksum = crc32::update(self.checksum, &crc32::IEEE_TABLE, data);
+        let mut h = Hasher::new_with_initial(self.checksum);
+        h.update(data);
+        self.checksum = h.finalize();
     }
 
     /// Reset the checksum and byte counter.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! This library is based on the gzip header functionality in the
 //! [flate2](https://crates.io/crates/flate2) crate.
 
-extern crate crc;
+extern crate crc32fast;
 
 mod crc_reader;
 


### PR DESCRIPTION
Hi there,

I noticed that "crc32fast" is being used widely in image processing crates such as [png](https://github.com/image-rs/image-png), [image](https://github.com/image-rs/image). It could be a better choice. This PR replaces crc with crc32fast.

Best,
Yu